### PR TITLE
Improving ref name and adding status info

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 | BULLETTRAIN_CAR_GIT_PAINT        | Colour override for the car't paint.            | red:white     |
 | BULLETTRAIN_CAR_GIT_SYMBOL_ICON  | Icon displayed on the car.                      | ``           |
 | BULLETTRAIN_CAR_GIT_SYMBOL_PAINT | Colour override for the car's symbol.           | red:white     |
+| BULLETTRAIN_CAR_GIT_DIRTY_ICON   | Icon displayed when there are changes.          | `✘`           |
+| BULLETTRAIN_CAR_GIT_DIRTY_PAINT  | Colour override for the dirty symbol.           | red:white     |
+| BULLETTRAIN_CAR_GIT_CLEAN_ICON   | Icon displayed when there are no changes.       | `✔`           |
+| BULLETTRAIN_CAR_GIT_CLEAN_PAINT  | Colour override for the clean symbol.           | green:white   |
 
 # Contribute
 

--- a/bullettrain-git.go
+++ b/bullettrain-git.go
@@ -13,6 +13,10 @@ const (
 	carPaint       = "black:white"
 	gitSymbolPaint = "red:white"
 	gitSymbolIcon  = ""
+	gitDirtyPaint  = "red:white"
+	gitDirtyIcon   = "✘"
+	gitCleanPaint  = "green:white"
+	gitCleanIcon   = "✔"
 )
 
 // Car for Git
@@ -36,6 +40,36 @@ func paintedSymbol() string {
 	return ansi.Color(symbolIcon, symbolPaint)
 }
 
+func paintStatus(pwd string) string {
+	var dirtyIcon string
+	if dirtyIcon = os.Getenv("BULLETTRAIN_CAR_GIT_DIRTY_ICON"); dirtyIcon == "" {
+		dirtyIcon = gitDirtyIcon
+	}
+
+	var dirtyPaint string
+	if dirtyPaint = os.Getenv("BULLETTRAIN_CAR_GIT_DIRTY_PAINT"); dirtyPaint == "" {
+		dirtyPaint = gitDirtyPaint
+	}
+
+	var cleanIcon string
+	if cleanIcon = os.Getenv("BULLETTRAIN_CAR_GIT_CLEAN_ICON"); cleanIcon == "" {
+		cleanIcon = gitCleanIcon
+	}
+
+	var cleanPaint string
+	if cleanPaint = os.Getenv("BULLETTRAIN_CAR_GIT_CLEAN_PAINT"); cleanPaint == "" {
+		cleanPaint = gitCleanPaint
+	}
+
+	cmd := exec.Command("git", "-C", pwd, "status", "--porcelain")
+	out, _ := cmd.Output()
+	if len(out) > 0 {
+		return ansi.Color(dirtyIcon, dirtyPaint)
+	} else {
+		return ansi.Color(cleanIcon, cleanPaint)
+	}
+}
+
 // GetPaint returns the calculated end paint string for the car.
 func (c *Car) GetPaint() string {
 	if c.paint = os.Getenv("BULLETTRAIN_CAR_GIT_PAINT"); c.paint == "" {
@@ -56,15 +90,25 @@ func (c *Car) CanShow() bool {
 	return false
 }
 
-func currentBranchName(pwd string) string {
-	cmd := exec.Command(
-		"git", "-C", pwd, "rev-parse", "--abbrev-ref", "HEAD")
-	cmdOut, _ := cmd.Output()
-	if string(cmdOut) == "" {
+func currentHeadName(pwd string) string {
+	cmd := exec.Command("git", "-C", pwd, "symbolic-ref", "HEAD")
+	ref, err := cmd.Output()
+	if err != nil {
+		cmd := exec.Command("git", "-C", pwd, "describe", "--tags", "--exact-match", "HEAD")
+		ref, err = cmd.Output()
+		if err != nil {
+			cmd := exec.Command("git", "-C", pwd, "rev-parse", "--short", "HEAD")
+			ref, _ = cmd.Output()
+		}
+	}
+
+	ref = []byte(strings.Replace(string(ref), "refs/heads/", "", 1))
+
+	if string(ref) == "" {
 		return ""
 	}
 
-	return strings.TrimRight(string(cmdOut), "\n")
+	return strings.TrimRight(string(ref), "\n")
 }
 
 // Render builds and passes the end product of a completely composed car onto
@@ -73,9 +117,10 @@ func (c *Car) Render(out chan<- string) {
 	defer close(out) // Always close the channel!
 	carPaint := ansi.ColorFunc(c.GetPaint())
 
-	out <- fmt.Sprintf("%s%s",
+	out <- fmt.Sprintf("%s%s%s",
 		paintedSymbol(),
-		carPaint(currentBranchName(c.Pwd)))
+		carPaint(currentHeadName(c.Pwd)),
+		paintStatus(c.Pwd))
 }
 
 // GetSeparatorPaint overrides the Fg/Bg colours of the right hand side

--- a/bullettrain-git.go
+++ b/bullettrain-git.go
@@ -104,7 +104,7 @@ func currentHeadName(pwd string) string {
 
 	ref = []byte(strings.Replace(string(ref), "refs/heads/", "", 1))
 
-	if string(ref) == "" {
+	if len(ref) == 0 {
 		return ""
 	}
 


### PR DESCRIPTION
This PR is adding the possibility to display not only the branch name, but also the tag name or commit number if in detached branch. It's also adding an indicator of a clean or a dirty repository.